### PR TITLE
Ip 35 multiple brags

### DIFF
--- a/scripts/nominations.coffee
+++ b/scripts/nominations.coffee
@@ -311,6 +311,8 @@ module.exports = (robot) ->
           msg.send "Your brag about @#{successNames} was successfully retrieved and processed!"
         if errorReasons isnt ""
           msg.send errorReasons
+        if successCount == 0
+          return
 
         queryJson = getQueryJson("brag", successCount)
         jiraSearchUrl = jiraBaseUrl + "search"


### PR DESCRIPTION
Updated the regex to recognize various multiple names listed in a brag post to create a separate Jira brag for each. Pulled the guts out of the respond to brag code, so that it could be used in future refactoring by the HVA nomination response as well (instead of having duplicate code). Also added a check against the Jira posts retrieved to confirm the ID numbers match what was just submitted, instead of assuming the first one returned is the correct brag.