### PR TITLE
Monopoly updates to help streamline purchasing and next turns

### DIFF
--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -192,7 +192,6 @@ module.exports = (robot) ->
         balance -= amount
         account.balance = balance
         robot.brain.set 'monopolyAccounts', accounts
-        robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "$#{amount} subtracted from #{account.name}."
         robot.messageRoom process.env.HUBOT_ROOM_ADMIN_MONOPOLY, "$#{amount} subtracted from #{account.name}."
 
   sendToJail = (players, playerIndex) ->

--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -102,6 +102,10 @@ module.exports = (robot) ->
     robot.brain.set 'monopolyTurn', turn
     turn
 
+    playerIndex = robot.brain.get 'monopolyTurn'
+    turnState = robot.brain.get 'monopolyTurnState'
+    robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "\nCurrent turn is now: #{players[playerIndex].name} #{turnState}"
+
   updatePlayerInJail = (players, playerIndex, roll) ->
     current = players[playerIndex]
 

--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -566,7 +566,10 @@ module.exports = (robot) ->
           buyerIndex = _.findIndex(players, (player) ->
             player.name.toLowerCase() == buyerName.toLowerCase() 
           )
+
+          player = players[buyerIndex].name
           msg.send "#{players[buyerIndex].name} pays $#{soldPrice} for #{data[players[playerIndex].location].name}. #{bankerInstructions}"
+          updatePlayerAccount(player, soldPrice)
           updateProperty(data, players, playerIndex, buyerIndex)
           robot.brain.set 'monopolyTurnState', 'roll'
           setNextPlayer()

--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -189,6 +189,7 @@ module.exports = (robot) ->
         account.balance = balance
         robot.brain.set 'monopolyAccounts', accounts
         robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "$#{amount} subtracted from #{account.name}."
+        robot.messageRoom process.env.HUBOT_ROOM_ADMIN_MONOPOLY, "$#{amount} subtracted from #{account.name}."
 
   sendToJail = (players, playerIndex) ->
     players[playerIndex].location = 10

--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -249,10 +249,12 @@ module.exports = (robot) ->
     else if player.location == 4
       # Income Tax
       msg.send "Stacy discovered you haven't submitted receipts for the past two months. Pay $200. #{bankerInstructions}"
+      updatePlayerAccount(player.name, 200)
       setNextPlayer()
     else if player.location == 38
       # Luxury Tax
       msg.send "Vasudha needs a new pair of shoes. Pay $75. #{bankerInstructions}"
+      updatePlayerAccount(player.name, 75)
       setNextPlayer()
     else if player.location == 20
       # Free Parking (until money tracked in game, no bonus for Free Parking)


### PR DESCRIPTION
Now when someone buys a property instead of having to wait for someone to mark their account as having paid for it, we will handle it automagically.
Also when we determine and set who has the next turn, we will also display that information to the room so people will know who is next.