### PR TITLE
Some more monopoly updates

### DIFF
--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -100,11 +100,11 @@ module.exports = (robot) ->
     if (turn == players.length)
       turn = 0
     robot.brain.set 'monopolyTurn', turn
-    turn
 
     playerIndex = robot.brain.get 'monopolyTurn'
     turnState = robot.brain.get 'monopolyTurnState'
     robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "\nCurrent turn is now: #{players[playerIndex].name} #{turnState}"
+    turn
 
   updatePlayerInJail = (players, playerIndex, roll) ->
     current = players[playerIndex]

--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -188,11 +188,13 @@ module.exports = (robot) ->
     account = getAccount(player, accounts)
     if account
       balance = parseInt account.balance
+      oldBalance = balance
       if balance > amount
         balance -= amount
+        newBalance = balance
         account.balance = balance
         robot.brain.set 'monopolyAccounts', accounts
-        robot.messageRoom process.env.HUBOT_ROOM_ADMIN_MONOPOLY, "$#{amount} subtracted from #{account.name}."
+        robot.messageRoom process.env.HUBOT_ROOM_ADMIN_MONOPOLY, "#{account.name} account updated from #{oldBalance} to #{newBalance}."
 
   sendToJail = (players, playerIndex) ->
     players[playerIndex].location = 10


### PR DESCRIPTION
Updated the message for admin room to explain the previous and new balance for a team instead of the previous message saying they paid a specific amount.

Also, hopefully fixed the ordering issue by returning the implicit turn at the end of setting next player