### PR TITLE
Fix next turn message order with change to set topic instead

### DIFF
--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -194,7 +194,7 @@ module.exports = (robot) ->
         newBalance = balance
         account.balance = balance
         robot.brain.set 'monopolyAccounts', accounts
-        robot.messageRoom process.env.HUBOT_ROOM_ADMIN_MONOPOLY, "#{account.name} account updated from #{oldBalance} to #{newBalance}."
+        robot.messageRoom process.env.HUBOT_ROOM_ADMIN_MONOPOLY, "#{account.name} account updated from $#{oldBalance} to $#{newBalance}."
 
   sendToJail = (players, playerIndex) ->
     players[playerIndex].location = 10

--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -103,7 +103,7 @@ module.exports = (robot) ->
 
     playerIndex = robot.brain.get 'monopolyTurn'
     turnState = robot.brain.get 'monopolyTurnState'
-    msg.send "\nCurrent turn is now: #{players[playerIndex].name} #{turnState}"
+    msg.send "/topic Current turn is now: #{players[playerIndex].name} #{turnState}"
     turn
 
   updatePlayerInJail = (players, playerIndex, roll) ->


### PR DESCRIPTION
Swap out usage of robot.messageRoom with msg.send where we set the topic to whoever rolls next. This way the topic is changed and anyone joining at any point can see who is next and also changing topic will post the message in the room as well.

I also updated the admin account balance changed message to bring back in the dollar sign before the amounts, since I accidentally removed that in the last PR.