### PR TITLE
Add optional memo to bank commands

### DIFF
--- a/scripts/banker.coffee
+++ b/scripts/banker.coffee
@@ -28,43 +28,49 @@ module.exports = (robot) ->
       \thsbot bank subtract amount (from) teamName\n
       \thsbot bank set teamName balance (to) amount\n'
 
-  robot.respond /bank subtract \$*(\d+) (from )?(delta city|gotham|dmz|monterrey|houston|dallas)$/i, (msg) ->
+  robot.respond /bank subtract \$*(\d+) (from )?(delta city|gotham|dmz|monterrey|houston|dallas)( for)?( .+)?$/i, (msg) ->
     if _.contains allowedRooms, msg.envelope.room
       accounts = robot.brain.get 'monopolyAccounts'
       amount = parseInt msg.match[1]
       accountName = msg.match[3]
       account = getAccount(accountName, accounts)
       if account
-        balance = parseInt account.balance
-        if balance > amount
+        originalBalance = parseInt account.balance
+        balance = originalBalance
+        if balance >= amount
           balance -= amount
           account.balance = balance
+          memo = ''
+          if msg.match[5] then memo = " for#{msg.match[5]}"
+          msg.send "$#{amount} subtracted from #{account.name}#{memo}."
+          robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "#{account.name} account updated from $#{originalBalance} to $#{balance}#{memo}."
           robot.brain.set 'monopolyAccounts', accounts
-          msg.send "$#{amount} subtracted from #{account.name}."
-          robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "$#{amount} subtracted from #{account.name}."
         else 
           msg.send "#{account.name} doesn't have enough money to do that! Balance: $#{account.balance}"
       else
         msg.send "I don't know #{team}."
         
 
-  robot.respond /bank add \$*(\d+) (to )?(delta city|gotham|dmz|monterrey|houston|dallas)$/i, (msg) ->
+  robot.respond /bank add \$*(\d+) (to )?(delta city|gotham|dmz|monterrey|houston|dallas)( for)?( .+)?$/i, (msg) ->
     if _.contains allowedRooms, msg.envelope.room
       accounts = robot.brain.get 'monopolyAccounts'
       amount = parseInt msg.match[1]
       accountName = msg.match[3]
       account = getAccount(accountName, accounts)
       if account
-        balance = parseInt account.balance
+        originalBalance = parseInt account.balance
+        balance = originalBalance
         balance += amount
         account.balance = balance
+        memo = ''
+        if msg.match[5] then memo = " for#{msg.match[5]}"
         robot.brain.set 'monopolyAccounts', accounts
         msg.send "$#{amount} added to #{account.name}. (coin)"
-        robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "$#{amount} added to #{account.name}. (coin)"
+        robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "#{account.name} account updated from $#{originalBalance} to $#{balance}#{memo}. (coin)"
       else
         msg.send "I don't know #{team}."
 
-  robot.respond /bank transfer \$*(\d+) from (delta city|gotham|dmz|monterrey|houston|dallas) to (delta city|gotham|dmz|monterrey|houston|dallas)$/i, (msg) ->
+  robot.respond /bank transfer \$*(\d+) from (delta city|gotham|dmz|monterrey|houston|dallas) to (delta city|gotham|dmz|monterrey|houston|dallas)( for)?( .+)?$/i, (msg) ->
     if _.contains allowedRooms, msg.envelope.room
       amount = parseInt msg.match[1]
       fromName = msg.match[2].toLowerCase()
@@ -87,11 +93,13 @@ module.exports = (robot) ->
             toBalance += amount
             fromAccount.balance = fromBalance
             toAccount.balance = toBalance
+            memo = ''
+            if msg.match[5] then memo = " for#{msg.match[5]}"
             robot.brain.set 'monopolyAccounts', accounts
             msg.send "$#{amount} sent from #{fromAccount.name} to #{toAccount.name}."
-            robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "$#{amount} sent from #{fromAccount.name} to #{toAccount.name}."
+            robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "$#{amount} sent from #{fromAccount.name} to #{toAccount.name}#{memo}."
 
-  robot.respond /bank set (delta city|gotham|dmz|monterrey|houston|dallas) balance (to )?\$*(\d+)$/i, (msg) ->
+  robot.respond /bank set (delta city|gotham|dmz|monterrey|houston|dallas) balance (to )?\$*(\d+)( for)?( .+)?$/i, (msg) ->
     if _.contains allowedRooms, msg.envelope.room
       accounts = robot.brain.get 'monopolyAccounts'
       accountName = msg.match[1]
@@ -103,7 +111,9 @@ module.exports = (robot) ->
         accounts.push { name: accountName, balance: newBalance }
         message = "Account created for #{accountName} with a balance of $#{newBalance}"
       else
-        message = "#{accountName} balance set from $#{account.balance} to $#{newBalance}"
+        memo = ''
+        if msg.match[5] then memo = " for#{msg.match[5]}"
+        message = "#{accountName} balance set from $#{account.balance} to $#{newBalance}#{memo}."
         account.balance = newBalance
       robot.brain.set 'monopolyAccounts', accounts
       msg.send message


### PR DESCRIPTION
can send something like "bank add 200 to Dallas for today's brown bag" so the message to the monopoly room is clearer. It also displays "updated from $X to $Y" for add and subtract commands.