### PR TITLE
Silent auction commands

### DIFF
--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -1283,9 +1283,9 @@ module.exports = (robot) ->
         for bid in bids
           bidList += "#{bid.username} - $#{bid.amount}\n"
         if bids.length == 0
-          msg.send 'No bids recorded yet.'
+          robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, 'No bids recorded yet.'
         else
-          msg.send bidList
+          robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, bidList
 
   # undocumented until this is prettier
   robot.respond /monopoly dump log$/i, (msg) ->

--- a/scripts/monopoly.coffee
+++ b/scripts/monopoly.coffee
@@ -1122,7 +1122,7 @@ module.exports = (robot) ->
       bids.push { username: username, amount: bidAmount }
       robot.brain.set 'monopolyBids', bids
       msg.send "$#{bidAmount} bid recorded from #{username}."
-      robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY_ADMINS, "#{username} submitted a bid."
+      robot.messageRoom process.env.HUBOT_ROOM_MONOPOLY, "#{username} submitted a bid."
     else
       msg.send 'There is not an active auction to bid on.'
 


### PR DESCRIPTION
Adds the silent auction commands. It doesn't handle what the bidding is for, so admins will intervene after the auction is over to transfer the house or property for the determined amount. Bid amounts will be secret (even from admins) unless the "dump bids" admin command is used, in case there's a dispute to resolve.