### PR TITLE
Allow any number of spaces in brags/hvas

### DIFF
--- a/scripts/nominations.coffee
+++ b/scripts/nominations.coffee
@@ -297,7 +297,7 @@ module.exports = (robot) ->
   robot.respond /hva help$/i, (msg) ->
     msg.send nominateHelpText
 
-  robot.respond /brag (about |on )?((@[a-z0-9]+(, and |, & |, | and | & | )?)+)(.+)/i, (msg) ->
+  robot.respond /brag *(about|on)? *((@[a-z0-9]+( *, *and *| *, *& *| *, *| *and *| *& *| *)?)+)(.+)/i, (msg) ->
     #console.log("robot name: " + robot.name)
     sender = msg.message.user.name
     #console.log("sender: " + sender)
@@ -381,7 +381,7 @@ module.exports = (robot) ->
             else
               msg.send "Unable to match brag(s) with Jira results. Check the Jira HVA project to confirm success."
 
-  robot.respond /hva (to |for )@([a-zA-Z0-9]+) for (DFE|PAV|COM|PLG|OWN|GRIT|HUMILITY|CANDOR|CURIOSITY|AGENCY)(.+)/i, (msg) ->
+  robot.respond /hva *(to *|for *)?@([a-zA-Z0-9]+) *for *(DFE|PAV|COM|PLG|OWN|GRIT|HUMILITY|CANDOR|CURIOSITY|AGENCY)(.+)/i, (msg) ->
     #console.log("robot name: " + robot.name)
     sender = msg.message.user.name
     #console.log("sender: " + sender)


### PR DESCRIPTION
Works with any number of spaces around the names, ands, commas, etc.

I checked it in the bot as well to confirm the match indexes are still correct with the updated regex.

![brag spaces](https://user-images.githubusercontent.com/3969554/45228523-004b5200-b289-11e8-8a3f-f1d3526c56fc.png)

![hva spaces](https://user-images.githubusercontent.com/3969554/45228529-03ded900-b289-11e8-867d-87093218efd1.png)
