### PR TITLE
Add tracking food trucks by date

### DIFF
--- a/scripts/foodtruck.coffee
+++ b/scripts/foodtruck.coffee
@@ -6,75 +6,77 @@
 
 date = require 'datejs'
 
+trucksbyDayOfWeek = [null,
+          [
+            {
+              breakfast: null,
+              lunch:
+                {
+                  name: "Paprika",
+                  site: "the internet",
+                  time: "11:30am - 1:30pm"
+                }
+            },
+            {
+              breakfast: null,
+              lunch:
+                {
+                  name: "Mission Hot Dogs",
+                  site: "https://twitter.com/MissionHotDogs",
+                  time: "11:30am - 2:00pm"
+                }
+            }
+          ],
+          [
+            null,
+            {
+              breakfast:
+                {
+                  name: "Top Taco",
+                  site: "http://www.tacofoodgroup.com/",
+                  time: "8:00am - 10:15am"
+                }
+              lunch:
+                {
+                  name: "Cafe Ybor",
+                  site: "http://www.cafeybor.com",
+                  time: "11:00am - 1:30pm"
+                }
+            }
+          ],
+          [
+            null,
+            null
+          ],
+          [
+            {
+              breakfast:
+                {
+                  name: "Top Taco",
+                  site: "http://www.tacofoodgroup.com/",
+                  time: "8:00am - 10:15am"
+                }
+              lunch: null
+            },
+            {
+              breakfast: null,
+              lunch:
+                {
+                  name: "Heros Gyros",
+                  site: "http://www.theherosgyros.com",
+                  time: "11:30am - 2:00pm"
+                }
+            }
+          ],
+          [
+            null,
+            null
+          ],
+          null]
+
 module.exports = (robot) ->
   robot.respond /(food truck|foodtruck)$/i, (msg) ->
-    trucks = [null,
-              [
-                {
-                  breakfast: null,
-                  lunch:
-                    {
-                      name: "Paprika",
-                      site: "the internet",
-                      time: "11:30am - 1:30pm"
-                    }
-                },
-                {
-                  breakfast: null,
-                  lunch:
-                    {
-                      name: "Mission Hot Dogs",
-                      site: "https://twitter.com/MissionHotDogs",
-                      time: "11:30am - 2:00pm"
-                    }
-                }
-              ],
-              [
-                null,
-                {
-                  breakfast:
-                    {
-                      name: "Top Taco",
-                      site: "http://www.tacofoodgroup.com/",
-                      time: "8:00am - 10:15am"
-                    }
-                  lunch:
-                    {
-                      name: "Cafe Ybor",
-                      site: "http://www.cafeybor.com",
-                      time: "11:00am - 1:30pm"
-                    }
-                }
-              ],
-              [
-                null,
-                null
-              ],
-              [
-                {
-                  breakfast:
-                    {
-                      name: "Top Taco",
-                      site: "http://www.tacofoodgroup.com/",
-                      time: "8:00am - 10:15am"
-                    }
-                  lunch: null
-                },
-                {
-                  breakfast: null,
-                  lunch:
-                    {
-                      name: "Heros Gyros",
-                      site: "http://www.theherosgyros.com",
-                      time: "11:30am - 2:00pm"
-                    }
-                }
-              ],
-              [
-                null,
-                null
-              ],
-              null]
+
     today = new Date()
     day = today.getDay()
     hour = today.getHours()
@@ -83,12 +85,12 @@ module.exports = (robot) ->
       day = day + 1
       today.setDate(today.getDate() + 1)
       weekday = today.toString("dddd")
-    truck = trucks[day]
+    truck = trucksbyDayOfWeek[day]
     if truck
       if truck.length == 2
         truck = truck[Date.today().getWeek() % 2]
       if not truck
-        truck = trucks[new Date().getDay()][(Date.today().getWeek() + 1) % 2]
+        truck = trucksbyDayOfWeek[new Date().getDay()][(Date.today().getWeek() + 1) % 2]
         if (truck && truck.lunch)
           message = "No food truck today, but next week it will be #{truck.lunch.name}"
         else

--- a/scripts/foodtruck.coffee
+++ b/scripts/foodtruck.coffee
@@ -6,7 +6,7 @@
 
 date = require 'datejs'
 
-trucksbyDayOfWeek = [null,
+trucksByDayOfWeek = [null,
           [
             {
               breakfast: null,
@@ -96,7 +96,7 @@ module.exports = (robot) ->
       day = day + 1
       today.setDate(today.getDate() + 1)
       weekday = today.toString("dddd")
-    truck = trucksbyDayOfWeek[day]
+    truck = trucksByDayOfWeek[day]
     if truck
       if truck.length == 2
         truck = truck[Date.today().getWeek() % 2]
@@ -105,7 +105,7 @@ module.exports = (robot) ->
         if(truck)
           message = "The lunch food truck for " + weekday + " is #{truck.name}, and they will be here from #{truck.time}, which you can verify here: #{truck.site}"
         else
-          truck = trucksbyDayOfWeek[new Date().getDay()][(Date.today().getWeek() + 1) % 2]
+          truck = trucksByDayOfWeek[new Date().getDay()][(Date.today().getWeek() + 1) % 2]
           if (truck && truck.lunch)
             message = "No food truck today, but next week it will be #{truck.lunch.name}"
           else

--- a/scripts/foodtruck.coffee
+++ b/scripts/foodtruck.coffee
@@ -96,30 +96,31 @@ module.exports = (robot) ->
       day = day + 1
       today.setDate(today.getDate() + 1)
       weekday = today.toString("dddd")
-    truck = trucksByDayOfWeek[day]
-    if truck
-      if truck.length == 2
-        truck = truck[Date.today().getWeek() % 2]
-      if not truck
-        truck = (trucksByDate.filter (i) -> i.day is today.getDate())[0].truck
-        if(truck)
-          message = "The lunch food truck for " + weekday + " is #{truck.name}, and they will be here from #{truck.time}, which you can verify here: #{truck.site}"
-        else
+    truckbyDate = (trucksByDate.filter (i) -> i.day is today.getDate())
+    if truckByDate?
+      truck = truckByDate[0].truck
+      msg.send "The lunch food truck for " + weekday + " is #{truck.name}, and they will be here from #{truck.time}, which you can verify here: #{truck.site}"
+    else
+      truck = trucksByDayOfWeek[day]
+      if truck
+        if truck.length == 2
+          truck = truck[Date.today().getWeek() % 2]
+        if not truck
           truck = trucksByDayOfWeek[new Date().getDay()][(Date.today().getWeek() + 1) % 2]
           if (truck && truck.lunch)
             message = "No food truck today, but next week it will be #{truck.lunch.name}"
           else
             message = "No food truck today :sadpanda:"
-        msg.send message
-        return
-      if truck.breakfast
-        message = "The breakfast food truck for " + weekday + " is #{truck.breakfast.name}, and they will be here from #{truck.breakfast.time}, which you can verify here: #{truck.breakfast.site}"
-        msg.send message
-      if truck.lunch
-        message = "The lunch food truck for " + weekday + " is #{truck.lunch.name}, and they will be here from #{truck.lunch.time}, which you can verify here: #{truck.lunch.site}"
-        msg.send message
-      msg.send ":chompy:"
-    else
-      msg.send "Awww beans! There's no food truck today. :sadpanda: Try `hsbot lunch me`! ;)"
+          msg.send message
+          return
+        if truck.breakfast
+          message = "The breakfast food truck for " + weekday + " is #{truck.breakfast.name}, and they will be here from #{truck.breakfast.time}, which you can verify here: #{truck.breakfast.site}"
+          msg.send message
+        if truck.lunch
+          message = "The lunch food truck for " + weekday + " is #{truck.lunch.name}, and they will be here from #{truck.lunch.time}, which you can verify here: #{truck.lunch.site}"
+          msg.send message
+        msg.send ":chompy:"
+      else
+        msg.send "Awww beans! There's no food truck today. :sadpanda: Try `hsbot lunch me`! ;)"
   robot.respond /food truck schedule$/i, (msg) ->
     msg.send "Here is the food truck schedule for The Campus: https://raw.githubusercontent.com/HeadspringLabs/hsbot/master/foodtruckschedule.jpg"

--- a/scripts/foodtruck.coffee
+++ b/scripts/foodtruck.coffee
@@ -74,6 +74,17 @@ trucksbyDayOfWeek = [null,
           ],
           null]
 
+trucksByDate = [
+  {
+    day: 7,
+    truck: {
+      name: "Bigg Belly BBQ",
+      site: "https://www.facebook.com/Bigg-Belly-BBQ-Co-Austin-TX-1700920133505615/",
+      time: "11:30am - 1:30pm"
+    }
+  }
+]
+
 module.exports = (robot) ->
   robot.respond /(food truck|foodtruck)$/i, (msg) ->
 
@@ -90,11 +101,15 @@ module.exports = (robot) ->
       if truck.length == 2
         truck = truck[Date.today().getWeek() % 2]
       if not truck
-        truck = trucksbyDayOfWeek[new Date().getDay()][(Date.today().getWeek() + 1) % 2]
-        if (truck && truck.lunch)
-          message = "No food truck today, but next week it will be #{truck.lunch.name}"
+        truck = (trucksByDate.filter (i) -> i.day is today.getDate())[0].truck
+        if(truck)
+          message = "The lunch food truck for " + weekday + " is #{truck.name}, and they will be here from #{truck.time}, which you can verify here: #{truck.site}"
         else
-          message = "No food truck today :sadpanda:"
+          truck = trucksbyDayOfWeek[new Date().getDay()][(Date.today().getWeek() + 1) % 2]
+          if (truck && truck.lunch)
+            message = "No food truck today, but next week it will be #{truck.lunch.name}"
+          else
+            message = "No food truck today :sadpanda:"
         msg.send message
         return
       if truck.breakfast


### PR DESCRIPTION
Sometimes a food truck comes just once in a month, which won't work with our by week schedule we were using. So now when we don't find a truck for the current day when looking by day of the week, we then try to look by date and return it if its there. Otherwise fall back to our previous logic to look at the next week to tell people about that, or say there is no truck at all.